### PR TITLE
Add NQZ

### DIFF
--- a/iata-icao.csv
+++ b/iata-icao.csv
@@ -4301,6 +4301,7 @@
 "KZ","Shyghys Qazaqstan oblysy","UKK","UASK","Oskemen Airport (Ust-Kamenogorsk Airport)","50.03659821","82.49420166"
 "KZ","Almaty","TDK","","Taldykorgan Airport","45.12620163","78.4469986"
 "KZ","Astana","TSE","UACC","Astana International Airport","51.02220154","71.46690369"
+"KZ","Astana","NQZ","UACC","Nursultan Nazarbayev International Airport","51.02220154","71.46690369"
 "KZ","Atyrau oblysy","GUW","UATG","Atyrau Airport","47.12189865","51.82139969"
 "KZ","Almaty","ALA","UAAA","Almaty International Airport","43.35210037","77.04049683"
 "KZ","Qaraghandy oblysy","DZN","UAKD","Zhezkazgan Airport","47.708302","67.733299"


### PR DESCRIPTION
This is a rare case but IATA has changed the airport code of the capital of Kazakhstan ([at the moment](https://en.wikipedia.org/wiki/Astana#Names) it's called Astana) **from TSE to NQZ**.

Sources:
- https://www.rferl.org/a/kazakh-capital-renamed-after-nazarbaev-changes-airport-code-to-nqz/30658764.html
- https://www.flightradar24.com/data/airports/nqz


I think we have to keep the line with the old IATA code too for a historical lookup.