### PR TITLE
remove duplicated IATA codes

### DIFF
--- a/iata-icao.csv
+++ b/iata-icao.csv
@@ -20,7 +20,6 @@
 "AF","Khost","OLR","OASL","Forward Operating Base Salerno","33.3638","69.9561"
 "AF","Badakhshan","KWH","OAHN","Khwahan Airport","37.883","70.217"
 "AF","Ghazni","SBF","OADS","Sardeh Band Airport","33.3207","68.6365"
-"AF","Kabul","KBL","OAKB","Hamid Karzai International Airport","34.5659","69.2123"
 "AF","Badghis","LQN","OAQN","Qala i Naw Airport","34.985","63.1178"
 "AF","Badakhshan","FBD","OAFZ","Fayzabad Airport","37.1211","70.5181"
 "AF","Khost","KHT","OAKS","Khost Airfield","33.3334","69.952"

--- a/iata-icao.csv
+++ b/iata-icao.csv
@@ -832,7 +832,6 @@
 "BA","Federacija Bosne i Hercegovine","SJJ","LQSA","Sarajevo International Airport","43.8246","18.3315"
 "BA","Federacija Bosne i Hercegovine","TZL","LQTZ","Tuzla International Airport","44.4587","18.7248"
 "BB","Christ Church","BGI","TBPB","Grantley Adams International Airport","13.0746","-59.4925"
-"BB","Christ Church","BGI","TBPB","Grantley Adams International Airport","13.0747","-59.4925"
 "BD","Sylhet","ZYL","VGSY","Osmani International Airport","24.9632","91.8668"
 "BD","Khulna","JSR","VGJR","Jessore Airport","23.1838","89.1608"
 "BD","Chittagong","CGP","VGEG","Shah Amanat International Airport","22.2496","91.8133"

--- a/iata-icao.csv
+++ b/iata-icao.csv
@@ -1242,7 +1242,6 @@
 "BR","Pernambuco","REC","SBRF","Recife/Guararapes-Gilberto Freyre International Airport","-8.12649","-34.9236"
 "BR","Rio de Janeiro","CAW","SBCP","Bartolomeu Lysandro Airport","-21.6983","-41.3017"
 "BR","Pernambuco","CAU","SNRU","Caruaru Airport (Oscar Laranjeiras Airport)","-8.28239","-36.0135"
-"BR","Parana","AAG","SSYA","Avelino Vieira Airport","-24.1042","-49.7906"
 "BR","Ceara","ARX","SBAC","Aracati Airport","-4.56861","-37.8047"
 "BR","Rio Grande do Sul","CEL","SSCN","Canela Airport","-29.3706","-50.8322"
 "BR","Ceara","JJD","SBJE","Comte. Ariston Pessoa Regional Airport","-2.90667","-40.3581"


### PR DESCRIPTION
The air port was renamed and the code is duplicated with the new one
https://en.wikipedia.org/wiki/Kabul_International_Airport