### PR TITLE
Fix latitude of RNG

### DIFF
--- a/iata-icao.csv
+++ b/iata-icao.csv
@@ -8448,7 +8448,7 @@
 "US","California","RMY","KMPI","Mariposa-Yosemite Airport","37.5109","-120.04"
 "US","Tennessee","RNC","KRNC","Warren County Memorial Airport","35.6987","-85.8438"
 "US","Texas","RND","KRND","Randolph Air Force Base","29.5297","-98.2789"
-"US","Colorado","RNG","","Rangely Airport","-40.9398","-108.763"
+"US","Colorado","RNG","","Rangely Airport","40.0932","-108.763"
 "US","Wisconsin","RNH","KRNH","New Richmond Regional Airport","45.1483","-92.5381"
 "US","Alaska","IAN","PAIK","Bob Baker Memorial Airport","66.976","-160.437"
 "US","Nevada","RNO","KRNO","Reno-Tahoe International Airport","39.4991","-119.768"


### PR DESCRIPTION
The latitude of RNG should be north, not south.

![image](https://github.com/ip2location/ip2location-iata-icao/assets/7197135/cc0f7bcd-3d54-49f3-895e-a67cec93315c)
