### PR TITLE
Add airport: Milan-Linate

### DIFF
--- a/iata-icao.csv
+++ b/iata-icao.csv
@@ -3969,6 +3969,7 @@
 "IT","Lazio","FCO","LIRF","Rome–Fiumicino International Airport","41.8003","12.2389"
 "IT","Liguria","ALL","LIMG","Albenga Airport","44.0506","8.12743"
 "IT","Liguria","GOA","LIMJ","Genoa Cristoforo Colombo Airport","44.4133","8.8375"
+"IT","Lombardia","LIN","LIML","Milan-Linate Airport","45.4494","9.2783"
 "IT","Lombardia","MXP","LIMC","Milan-Malpensa Airport","45.6306","8.72811"
 "IT","Lombardia","VBS","LIPO","Brescia Airport (Gabriele D'Annunzio Airport)","45.4289","10.3306"
 "IT","Marche","AOI","LIPY","Ancona Falconara Airport","43.6163","13.3623"


### PR DESCRIPTION
- added alphabetically before Milan-Malpensa
- verified IATA and ICAO airport codes
- truncated lat/lon as retrieved from Wikipedia