### PR TITLE
Add Edmonton International Airport (YEG/CYEG)

### DIFF
--- a/iata-icao.csv
+++ b/iata-icao.csv
@@ -1335,6 +1335,7 @@
 "CA","Alberta","YBY","CYBF","Bonnyville Airport","54.3042","-110.744"
 "CA","Alberta","YCT","CYCT","Coronation Airport","52.075","-111.445"
 "CA","Alberta","YDC","","Drayton Valley Industrial Airport","53.2658","-114.96"
+"CA","Alberta","YEG","CYEG","Edmonton International Airport","53.3100","-113.579"
 "CA","Alberta","YET","CYET","Edson Airport","53.5789","-116.465"
 "CA","Alberta","YFI","","Fort MacKay/Firebag Aerodrome","57.2758","-110.977"
 "CA","Alberta","YGC","","Grande Cache Airport","53.9169","-118.874"


### PR DESCRIPTION
I've added the `Edmonton International Airport` (`YEG`/`CYEG`)

- Verified airport name, ICAO, and IATA codes
- Sorted alphabetically
- Coordinates were taken from Wikipedia and truncated