### PR TITLE
Update IATA code for Chisinau airport, from KIV to RMO

### DIFF
--- a/iata-icao.csv
+++ b/iata-icao.csv
@@ -4398,7 +4398,7 @@
 "MA","Tanger-Tetouan-Al Hoceima","TNG","GMTT","Tangier Ibn Battouta Airport","35.7269","-5.91689"
 "MA","Tanger-Tetouan-Al Hoceima","TTU","","Sania Ramel Airport","35.5943","-5.32002"
 "MD","Balti","BZY","LUBL","Balti International Airport","47.8431","27.7772"
-"MD","Chisinau","KIV","LUKK","Chisinau International Airport","46.9277","28.931"
+"MD","Chisinau","RMO","LUKK","Chisinau International Airport","46.9277","28.931"
 "ME","Berane","IVG","LYBR","Dolac Airport","42.839","19.862"
 "ME","Pljevlja","ZBK","","Zabljak Airport","43.1167","19.2333"
 "ME","Podgorica","TGD","LYPG","Podgorica Airport","42.3594","19.2519"


### PR DESCRIPTION
On January 24, 2024, Chișinău International Airport retired its former IATA code, KIV, in favor of the more modern code, RMO ([link](https://en.wikipedia.org/wiki/Chi%C8%99in%C4%83u_International_Airport)). This pull request updates this data.