### PR TITLE
Adding missing international airports from Brazil: CNF, GIG, GRU and VCP

### DIFF
--- a/iata-icao.csv
+++ b/iata-icao.csv
@@ -1074,6 +1074,7 @@
 "BR","Mato Grosso","VLP","SWVC","Vila Rica Municipal Airport","-9.97944","-51.1422"
 "BR","Minas Gerais","AAX","SBAX","Araxa Airport","-19.5632","-46.9604"
 "BR","Minas Gerais","AMJ","SNAR","Almenara Airport","-16.1839","-40.6672"
+"BR","Minas Gerais","CNF","SBCF","Tancredo Neves International Airport","-19.6336","-43.9686"
 "BR","Minas Gerais","DIQ","SNDV","Divinopolis Airport (Brigadeiro Cabral Airport)","-20.1807","-44.8709"
 "BR","Minas Gerais","DTI","SNDT","Diamantina Airport","-18.232","-43.6504"
 "BR","Minas Gerais","ESI","","Espinosa Airport","-14.9337","-42.81"

--- a/iata-icao.csv
+++ b/iata-icao.csv
@@ -1240,6 +1240,7 @@
 "BR","Sao Paulo","SSZ","SBST","Santos Air Force Base","-23.9281","-46.2997"
 "BR","Sao Paulo","UBT","SDUB","Ubatuba Airport","-23.4411","-45.0756"
 "BR","Sao Paulo","URB","SBUP","Castilho Airport (Urubupunga Airport)","-20.7771","-51.5648"
+"BR","Sao Paulo","VCP","SBKP","Viracopos-Campinas International Airport","-23.0081","-47.1344"
 "BR","Sao Paulo","VOT","SDVG","Votuporanga Airport (Domingos Pignatari Airport)","-20.4632","-50.0045"
 "BR","Sergipe","AJU","SBAR","Santa Maria Airport (Sergipe)","-10.984","-37.0703"
 "BR","Tocantins","AAI","SWRA","Arraias Airport","-13.0252","-46.8841"

--- a/iata-icao.csv
+++ b/iata-icao.csv
@@ -1186,6 +1186,7 @@
 "BR","Rio de Janeiro","BZC","SBBZ","Umberto Modiano Airport","-22.7709","-41.9631"
 "BR","Rio de Janeiro","CAW","SBCP","Bartolomeu Lysandro Airport","-21.6983","-41.3017"
 "BR","Rio de Janeiro","CFB","SBCB","Cabo Frio International Airport","-22.9217","-42.0743"
+"BR","Rio de Janeiro","GIG","SBGL","Galeao-Antonio Carlos Jobim International Airport","-22.8100","-43.2506"
 "BR","Rio de Janeiro","ITP","SDUN","Itaperuna Airport","-21.2193","-41.8759"
 "BR","Rio de Janeiro","MEA","SBME","Benedito Lacerda Airport","-22.343","-41.766"
 "BR","Rio de Janeiro","REZ","SDRS","Resende Airport","-22.4785","-44.4803"

--- a/iata-icao.csv
+++ b/iata-icao.csv
@@ -1224,6 +1224,7 @@
 "BR","Sao Paulo","CPQ","SDAM","Campo dos Amarais Airport","-22.8592","-47.1081"
 "BR","Sao Paulo","FRC","SIMK","Franca Airport (Ten. Lund Presotto-Franca State Airport)","-20.5922","-47.3829"
 "BR","Sao Paulo","GUJ","SBGW","Guaratingueta Airport","-22.7916","-45.2048"
+"BR","Sao Paulo","GRU","SBGR","Guarulhos International Airport","-23.4322","-46.4692"
 "BR","Sao Paulo","JLS","SDJL","Jales Airport","-20.293","-50.5464"
 "BR","Sao Paulo","JTC","SBAE","Moussa Nakhl Tobias-Bauru/Arealva State Airport","-22.1669","-49.0503"
 "BR","Sao Paulo","LIP","SBLN","Lins Airport","-21.664","-49.7305"


### PR DESCRIPTION
I use this list to map the location of our servers and noticed that some important airports from Brazil were missing.
I added them trying to follow the format and order of the list.

I got the airport codes and geolocations from https://airportcodes.aero/ and https://www.avcodes.co.uk/