### PR TITLE
Fixing the Chatham Island longitude which was incorrectly positive

### DIFF
--- a/iata-icao.csv
+++ b/iata-icao.csv
@@ -5084,7 +5084,7 @@
 "NZ","Canterbury","KBZ","NZKI","Kaikoura Aerodrome","-42.425","173.605"
 "NZ","Canterbury","TIU","NZTU","Richard Pearse Airport","-44.3028","171.225"
 "NZ","Canterbury","TWZ","NZUK","Pukaki Airport","-44.235","170.118"
-"NZ","Chatham Islands Territory","CHT","NZCI","Chatham Islands / Tuuta Airport","-43.81","176.457"
+"NZ","Chatham Islands Territory","CHT","NZCI","Chatham Islands / Tuuta Airport","-43.81","-176.457"
 "NZ","Canterbury","","NZRT","Rangiora Airfield WMS","-43.2892","172.5413"
 "NZ","Gisborne","GIS","NZGS","Gisborne Airport","-38.6633","177.978"
 "NZ","Hawke's Bay","NPE","NZNR","Hawke's Bay Airport","-39.4658","176.87"


### PR DESCRIPTION
Before: https://maps.google.com/?q=-43.81,176.457
After: https://maps.google.com/?q=-43.81,-176.457