### PR TITLE
Update Manas International Airport

### DIFF
--- a/iata-icao.csv
+++ b/iata-icao.csv
@@ -4313,7 +4313,7 @@
 "KE","Uasin Gishu","EDL","HKEL","Eldoret International Airport","0.404458","35.2389"
 "KE","Uasin Gishu","KTL","HKKT","Kitale Airport","0.971989","34.9586"
 "KE","Wajir","WJR","HKWJ","Wajir Airport","1.73324","40.0916"
-"KG","Chuy","FRU","UAFM","Manas International Airport","43.0613","74.4776"
+"KG","Chuy","BSZ","UCFM","Manas International Airport","43.0613","74.4776"
 "KG","Osh","OSS","UAFO","Osh Airport","40.609","72.7933"
 "KG","Issyk-Kul","IKU","UCFL","Issyk-Kul International Airport","42.5851","76.7064"
 "KH","Baat Dambang","BBM","VDBG","Battambang Airport","13.0956","103.224"


### PR DESCRIPTION
The Manas international airport code changed as of 9th August 2025. 

- changed to new iata
- changed to new icao